### PR TITLE
Add rclone_endTime and fix some bugs

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,12 +20,14 @@ if [ ! -z "${PUSHGATEWAY_URL}" ]; then
   checks=$(sed -n '/Checks: */ s///p' rclone.log | tail -n1)
 
   cat <<EOF | curl -s --data-binary @- "${PUSHGATEWAY_URL}/metrics/job/rclone/source/${src}/destination/${dst}"
-# TYPE rclone gauge
-rclone{what="transferred_bytes"} ${transferred}
-rclone{what="errors"} ${errors}
-rclone{what="checks"} ${checks}
-# TYPE rclone_endTime counter
-rclone_endTime $(date +%s)
+# TYPE rclone_transferred_bytes gauge
+rclone_transferred_bytes ${transferred}
+# TYPE rclone_errors gauge
+rclone_errors ${errors}
+# TYPE rclone_checks gauge
+rclone_checks ${checks}
+# TYPE rclone_end_time counter
+rclone_end_time $(date +%s)
 EOF
 
 echo "Metrics sent."

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,7 +15,7 @@ if [ ! -z "${PUSHGATEWAY_URL}" ]; then
 
   read src dst < <(sed -n '/.*with parameters.* "src:\([^"]\+\)" "dst:\([^"]\+\)"]/ s//\1 \2/p' rclone.log | tail -n1)
   transferred_raw=$(sed -n '/Transferred: *\([^ ]\+\) \([A-Za-z]\?\)Bytes.*/ s//\1\2/p' rclone.log | tail -n1)
-  transferred=$(numfmt --from=iec $transferred_raw)
+  transferred=$(numfmt --from=iec ${transferred_raw^^})
   errors=$(sed -n '/Errors: */ s///p' rclone.log | tail -n1)
   checks=$(sed -n '/Checks: */ s///p' rclone.log | tail -n1)
 
@@ -24,5 +24,9 @@ if [ ! -z "${PUSHGATEWAY_URL}" ]; then
 rclone{what="transferred_bytes"} ${transferred}
 rclone{what="errors"} ${errors}
 rclone{what="checks"} ${checks}
+# TYPE rclone_endTime counter
+rclone_endTime $(date +%s)
 EOF
+
+echo "Metrics sent."
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,7 +19,7 @@ if [ ! -z "${PUSHGATEWAY_URL}" ]; then
   errors=$(sed -n '/Errors: */ s///p' rclone.log | tail -n1)
   checks=$(sed -n '/Checks: */ s///p' rclone.log | tail -n1)
 
-  cat <<EOF | curl --data-binary @- "${PUSHGATEWAY_URL}/metrics/job/rclone/instance/${instance}/source/${src}/destination/${dst}"
+  cat <<EOF | curl -s --data-binary @- "${PUSHGATEWAY_URL}/metrics/job/rclone/source/${src}/destination/${dst}"
 # TYPE rclone gauge
 rclone{what="transferred_bytes"} ${transferred}
 rclone{what="errors"} ${errors}


### PR DESCRIPTION
* Format transferred to solve this issue : https://github.com/camptocamp/docker-rclone/issues/1
* Remove instance name to avoid duplication in the pushgateway.
* Remove curl output.
* Add rclone_endTime to solve this issue : https://github.com/camptocamp/docker-rclone/issues/2